### PR TITLE
feat: enable verbosity

### DIFF
--- a/cmd/when/main.go
+++ b/cmd/when/main.go
@@ -10,6 +10,11 @@ import (
 
 func main() {
 	flag.Usage = usage
+	verbose := flag.Bool("verbose", false, "Enable verbose output")
+	if *verbose {
+		fmt.Println("SELECTING VERBOSE")
+	}
+
 	flag.Parse()
 	input := flag.Arg(0)
 
@@ -23,7 +28,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	readableTime, err := when.When(input)
+	readableTime, err := when.When(input, *verbose)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/when/main.go
+++ b/cmd/when/main.go
@@ -10,12 +10,9 @@ import (
 
 func main() {
 	flag.Usage = usage
-	verbose := flag.Bool("verbose", false, "Enable verbose output")
-	if *verbose {
-		fmt.Println("SELECTING VERBOSE")
-	}
-
+	verbose := flag.Bool("verbose", false, "Enable verbose descriptions of time")
 	flag.Parse()
+
 	input := flag.Arg(0)
 
 	if input == "help" {
@@ -28,7 +25,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	readableTime, err := when.When(input, *verbose)
+	var readableTime string
+	var err error
+
+	if *verbose {
+		readableTime, err = when.WhenVerbosely(input)
+	} else {
+		readableTime, err = when.When(input)
+	}
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/when/main.go
+++ b/cmd/when/main.go
@@ -41,6 +41,7 @@ func main() {
 	fmt.Println(readableTime)
 }
 
+// TODO: adjust usage to indicate verbosity
 func usage() {
 	const userGuide = `
 Usage: when <TIME>

--- a/description/description.go
+++ b/description/description.go
@@ -6,54 +6,82 @@ import (
 	"time"
 )
 
-func Describe(t time.Time, verbose bool) string {
+func Describe(t time.Time) string {
 	currentTime := time.Now()
 	duration := currentTime.Sub(t)
-	absoluteDuration := time.Duration(int(math.Abs(float64(duration.Seconds()))))
 
-	description := absoluteTimeDifference(absoluteDuration)
-
-	isFutureTime := duration.Seconds() < 0
-	if isFutureTime {
-		description += " from now"
-	} else {
-		description += " ago"
+	absDiffSeconds := int(math.Abs(duration.Seconds()))
+	if absDiffSeconds >= month {
+		return t.Format("01/02/2006")
 	}
+	description := describeAbsDiff(absDiffSeconds)
 
+	inFuture := duration.Seconds() < 0
+	if inFuture {
+		description = "in " + description
+	}
 	return description
 }
 
-// TODO: correct plurals
-func absoluteTimeDifference(absoluteDuration time.Duration) string {
-	var description string
-	if absoluteDuration < minute {
-		description = "less than a minute"
-	} else if absoluteDuration < hour {
-		description = fmt.Sprintf("%d minutes", absoluteDuration/minute)
-	} else if absoluteDuration < day {
-		description = fmt.Sprintf("%d hours", absoluteDuration/hour)
-	} else if absoluteDuration < week {
-		description = fmt.Sprintf("%d days", absoluteDuration/day)
-	} else if absoluteDuration < month {
-		description = fmt.Sprintf("almost %d weeks", absoluteDuration/week)
-	} else if absoluteDuration < year {
-		months := absoluteDuration / month
-		if months < 1 {
-			description = "almost a month"
-		} else if month == 1 {
-			description = "around a month"
-		} else {
-			description = fmt.Sprintf("over %d months", months)
-		}
-	} else {
-		years := absoluteDuration / year
-		if years < 1 {
-			description = "almost a year"
-		} else if year == 1 {
-			description = "around a year"
-		} else {
-			description = fmt.Sprintf("over %d years", years)
-		}
+func DescribeVerbosely(t time.Time) string {
+	currentTime := time.Now()
+	duration := currentTime.Sub(t)
+
+	absDiffSeconds := int(math.Abs(duration.Seconds()))
+	description := describeAbsDiffVerbosely(absDiffSeconds)
+
+	inFuture := duration.Seconds() < 0
+	if inFuture {
+		return "in " + description
 	}
-	return description
+	return description + " ago"
+}
+
+func describeAbsDiff(secs int) string {
+	switch true {
+	case secs < 20:
+		return "now"
+	case secs < minute:
+		return fmt.Sprintf("%d%s", secs, "s")
+	case secs < hour:
+		return fmt.Sprintf("%d%s", secs/minute, "m")
+	case secs < day:
+		return fmt.Sprintf("%d%s", secs/hour, "h")
+	case secs < week:
+		return fmt.Sprintf("%d%s", secs/day, "d")
+	default:
+		return fmt.Sprintf("%d%s", secs/week, "w")
+	}
+}
+
+func describeAbsDiffVerbosely(secs int) string {
+	switch true {
+	case secs < 10:
+		return "just a few seconds"
+	case secs < minute/2:
+		return "less than 1 minute"
+	case secs < minute+15:
+		return "about 1 minute"
+	case secs < hour:
+		return grammaticalNumber(secs/minute, "minute")
+	case secs < day:
+		return grammaticalNumber(secs/hour, "hour")
+	case secs < week:
+		return grammaticalNumber(secs/day, "day")
+	case secs < month:
+		return "around " + grammaticalNumber(secs/week, "week")
+	case secs < year:
+		description := "roughly " + grammaticalNumber(secs/month, "month")
+		return description
+	default:
+		return "over " + grammaticalNumber(secs/year, "year")
+	}
+}
+
+func grammaticalNumber(numTimeUnits int, timeUnitName string) (description string) {
+	description = fmt.Sprintf("%d %s", numTimeUnits, timeUnitName)
+	if numTimeUnits > 1 {
+		description += "s" // plural time unit
+	}
+	return
 }

--- a/description/description.go
+++ b/description/description.go
@@ -6,15 +6,15 @@ import (
 	"time"
 )
 
-func Describe(t time.Time) string {
+func Describe(t time.Time, verbose bool) string {
 	currentTime := time.Now()
 	duration := currentTime.Sub(t)
 	absoluteDuration := time.Duration(int(math.Abs(float64(duration.Seconds()))))
 
 	description := absoluteTimeDifference(absoluteDuration)
 
-	futureTime := duration.Seconds() < 0
-	if futureTime {
+	isFutureTime := duration.Seconds() < 0
+	if isFutureTime {
 		description += " from now"
 	} else {
 		description += " ago"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,8 +10,8 @@ type TimeParser func(string) (time.Time, error)
 func Parse(input string) (time.Time, error) {
 	timeParsers := []TimeParser{parseRFCTime, parseUnixTime}
 
-	for _, timeParser := range timeParsers {
-		parsedTime, err := timeParser(input)
+	for _, parseTime := range timeParsers {
+		parsedTime, err := parseTime(input)
 		if err == nil {
 			return parsedTime, nil
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,17 +5,15 @@ import (
 	"time"
 )
 
-type ParseTimeFunc func(string) (time.Time, error)
+type TimeParser func(string) (time.Time, error)
 
 func Parse(input string) (time.Time, error) {
-	parseTimeFunc := []ParseTimeFunc{
-		parseRFC, parseUnixTime,
-	}
+	timeParsers := []TimeParser{parseRFCTime, parseUnixTime}
 
-	for _, timeParserFunc := range parseTimeFunc {
-		t, err := timeParserFunc(input)
+	for _, timeParser := range timeParsers {
+		parsedTime, err := timeParser(input)
 		if err == nil {
-			return t, nil
+			return parsedTime, nil
 		}
 	}
 

--- a/parser/rfc3339.go
+++ b/parser/rfc3339.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func parseRFC(input string) (time.Time, error) {
+func parseRFCTime(input string) (time.Time, error) {
 	layouts := []string{
 		time.RFC3339,
 		time.RFC3339Nano,
@@ -17,9 +17,9 @@ func parseRFC(input string) (time.Time, error) {
 	}
 
 	for _, layout := range layouts {
-		t, err := time.Parse(layout, input)
+		parsedTime, err := time.Parse(layout, input)
 		if err == nil {
-			return t, nil
+			return parsedTime, nil
 		}
 	}
 

--- a/parser/unixtime.go
+++ b/parser/unixtime.go
@@ -10,6 +10,6 @@ func parseUnixTime(input string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	t := time.Unix(unixTime, 0)
-	return t, nil
+	parsedTime := time.Unix(unixTime, 0)
+	return parsedTime, nil
 }

--- a/when.go
+++ b/when.go
@@ -12,3 +12,11 @@ func When(time string) (string, error) {
 	}
 	return description.Describe(parsedTime), nil
 }
+
+func WhenVerbosely(time string) (string, error) {
+	parsedTime, err := parser.Parse(time)
+	if err != nil {
+		return "", err
+	}
+	return description.DescribeVerbosely(parsedTime), nil
+}

--- a/when.go
+++ b/when.go
@@ -6,9 +6,9 @@ import (
 )
 
 func When(time string) (string, error) {
-	t, err := parser.Parse(time)
+	parsedTime, err := parser.Parse(time)
 	if err != nil {
 		return "", err
 	}
-	return description.Describe(t), nil
+	return description.Describe(parsedTime), nil
 }


### PR DESCRIPTION
Enable verbose output for time descriptions. Some examples:


> "in 4w" can be verbosely described as "in around 4 weeks"
> "now" can be verbosely described as "less than 10 seconds ago"